### PR TITLE
Added checking of request content length

### DIFF
--- a/lib/src/services/CommandableHttpService.dart
+++ b/lib/src/services/CommandableHttpService.dart
@@ -87,7 +87,7 @@ abstract class CommandableHttpService extends RestService {
           (angel.RequestContext req, angel.ResponseContext res) async {
         var params = {};
 
-        if (req.contentType != null) {
+        if (req.contentType != null && req.headers.contentLength > 0) {
           await req.parseBody();
           params = req.bodyAsMap ?? {};
         }


### PR DESCRIPTION
In cases when the content-type is specified but the body is empty then it fails during the body parsing.